### PR TITLE
Change Section 2.5 Label page header

### DIFF
--- a/slides/02-Developers/04-labels.html.md
+++ b/slides/02-Developers/04-labels.html.md
@@ -1,5 +1,5 @@
 ---
-title: Labeling Form Controls and Interactive Elements
+title: Labels
 toc: Labels
 chapter: Writing Code
 style: |


### PR DESCRIPTION
The table of contents has a header written as Labels and the page header says Labeling Form Controls and Interactive Elements. This format of the table of contents is not consistent with the rest of the page headers.