### PR TITLE
Add support for multiple assertions

### DIFF
--- a/docs/_util/VerifyButton.mdx
+++ b/docs/_util/VerifyButton.mdx
@@ -1,30 +1,31 @@
 import { useState } from "react";
 
-export const VerifyButton = ({ error, checkExercise }) => {
-  const [isValid, setIsValid] = useState(null);
+export const VerifyButton = ({ checkExercise }) => {
+  const [feedback, setFeedback] = useState(null);
+  const success = "Well done!";
   const onClick = () => {
-    const result = checkExercise();
-    setIsValid(result);
+    const error = checkExercise();
+    setFeedback(error || success);
   };
   const renderButton = () => (
     <button type="button" className="button" onClick={onClick}>
       Verify
     </button>
   );
-  const renderMessage = () => {
-    if (isValid === null) {
-      return null;
+  const renderFeedback = () => {
+    if (feedback) {
+      const isSuccess = feedback === success;
+      return (
+        <span className={isSuccess ? "success" : "error"} role="alert">
+          {feedback}
+        </span>
+      );
     }
-    return (
-      <span className={isValid ? "success" : "error"} role="alert">
-        {isValid ? "Well done!" : error}
-      </span>
-    );
   };
   return (
     <div className="verify">
       {renderButton()}
-      {renderMessage()}
+      {renderFeedback()}
     </div>
   );
 };

--- a/docs/code/aria.mdx
+++ b/docs/code/aria.mdx
@@ -18,22 +18,21 @@ For this exercise, we will focus on one small part of WAI-ARIA called landmark r
 
 ```jsx live
 <>
-    <h3>ARIA Landmarks Exercise</h3>
-    How many landmarks did you find on the page?
-    <input type="text" id="landmarks" />
+  <h3>ARIA Landmarks Exercise</h3>
+  How many landmarks did you find on the page?
+  <input type="text" id="landmarks" />
 </>
 ```
 
 import { VerifyButton } from "../_util/VerifyButton.mdx";
 
 <VerifyButton
-  error="That is not the right number of landmarks on the page!"
   checkExercise={() => {
-    const link = document.getElementById("landmarks");
-    return (
-      link.value === '4' ||
-      link.value === 'four'
-    );
+    const { value } = document.getElementById("landmarks");
+    const isValid = value === "4" || value === "four";
+    if (!isValid) {
+      return "That is not the right number of landmarks on the page!";
+    }
   }}
 />
 

--- a/docs/code/headings.mdx
+++ b/docs/code/headings.mdx
@@ -24,9 +24,10 @@ The heading below is a fake heading made to look like a heading with an unsemant
 ```
 
 <VerifyButton
-  error="It doesn't look like you converted the div to a real heading."
   checkExercise={() => {
     const h3s = document.querySelectorAll("h3");
-    return h3s.length === 2;
+    if (h3s.length !== 2) {
+      return "It doesn't look like you converted the div to a real heading.";
+    }
   }}
 ></VerifyButton>

--- a/docs/code/images.mdx
+++ b/docs/code/images.mdx
@@ -29,10 +29,12 @@ This is an image without `alt` text. Turn on VoiceOver and listen to how it is r
 ```
 
 <VerifyButton
-  error="It doesn't look like you added an alt to your image."
   checkExercise={() => {
     const exercise = document.querySelectorAll("[class^=playgroundPreview]")[1];
     const images = Array.from(exercise.getElementsByTagName("img"));
-    return images.every((image) => Boolean(image.alt));
+    const missingAltTag = images.some((image) => !image.hasAttribute("alt"));
+    if (missingAltTag) {
+      return "It doesn't look like you added an alt to your image.";
+    }
   }}
 ></VerifyButton>

--- a/docs/code/keyboard-navigation.mdx
+++ b/docs/code/keyboard-navigation.mdx
@@ -43,13 +43,14 @@ can tab to the button and press <kbd>enter</kbd> to activate it using just the k
 import { VerifyButton } from "../_util/VerifyButton.mdx";
 
 <VerifyButton
-  error="It doesn't look like your custom button is accessible yet."
   checkExercise={() => {
     const [button] = document.getElementsByClassName("customButton");
-    return (
+    const isValid =
       button.hasAttribute("tabindex") &&
       button.getAttribute("tabindex") === "0" &&
-      button.getAttribute("role") === "button"
-    );
+      button.getAttribute("role") === "button";
+    if (!isValid) {
+      return "It doesn't look like your custom button is accessible yet.";
+    }
   }}
 />


### PR DESCRIPTION
This PR adds support for multiple assertions in the `VerifyButton` component, mirroring the same functionality in exerslide. Previously, `VerifyButton` only supported a single assertion